### PR TITLE
Remove voice.js import

### DIFF
--- a/botHandler.js
+++ b/botHandler.js
@@ -7,10 +7,10 @@
 const { joinVoiceChannel, getVoiceConnection } = require("@discordjs/voice");
 const { setEmptyChat, setBotPresence, clearChat } = require('./discord-helper.js');
 const { getAIResponse } = require('./aiCore.js');
-const { setMessageReaction, getChannelConfig , setReplyAsWebhook} = require('./discord-helper.js');
+// voice-related helper functions are also exported from discord-helper
+const { setMessageReaction, getChannelConfig , setReplyAsWebhook, setStartListening, getSpeech } = require('./discord-helper.js');
 const { getContextAsChunks } = require('./helper.js');
 const Context = require('./context.js');
-const { setStartListening, getSpeech } = require('./voice.js'); 
 
 
 // Run an AI request


### PR DESCRIPTION
## Summary
- remove unused `voice.js` import from `botHandler.js`
- note that the voice helper functions are provided by `discord-helper.js`

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6862e8e2e5fc8329b0b8900705134a73